### PR TITLE
Fix styling in Forien's Quest Log and Calendar/Weather

### DIFF
--- a/css/wfrp4e.css
+++ b/css/wfrp4e.css
@@ -15725,6 +15725,10 @@ box-shadow: none;
     font-size: 14px;
  }
 
+#calendar-events-form {
+  color: var(--actor-input-color);
+}
+
 .calendar-form-container {
   background: none !important;
 }
@@ -15900,7 +15904,6 @@ hr,
   padding: 4px 3px;
   border: 1px solid #5d513e;
   background: #080808;
-  width: 100px;
 }
 #dd-importer label{
   width: 140px;
@@ -15997,6 +16000,9 @@ hr,
     background: #290a0ad9 !important; 
     color: #d6d6d6 !important;
   }
+.quest-preview {
+    color: var(--actor-input-color);
+}
 
 
 .calendar-form-container #calendar-form-cDay-input,


### PR DESCRIPTION
This fixes following issues:
* import/export buttons in calendar settings too small
* white text on bright background in events window of calendar/weather
* white text on bright background in quest preview on some tabs